### PR TITLE
Remove build dependency on native Fortran compiler

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -32,7 +32,7 @@ test: all
 		cd F-FrontEnd/src && bash ./compile_all_test.sh;\
 	else\
 	    echo "Fortran tests disabled because of --without-native-fortran-compiler";\
-    fi
+	fi
 	cd test/C99; make clean; make CC=$(CC)
 
 install:

--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,7 @@ BINDIR=@OMNI_HOME@/bin
 T_FJMODULE=@T_FJMODULE@
 T_FJMODULE_REMOTE=http://omni-compiler.org/T_FJModule/20170523
 T_FJMODULE_LOCAL=T_FJModule
+WITH_NATIVE_FORTRAN_COMPILER=@WITH_NATIVE_FORTRAN_COMPILER@
 
 SUBDIRS=C-FrontEnd/src F-FrontEnd/src XcodeML-Common C-BackEnd F-BackEnd Driver/bin
 
@@ -27,7 +28,11 @@ all:
 	done
 
 test: all
-	cd F-FrontEnd/src && bash ./compile_all_test.sh
+	@if [ $(WITH_NATIVE_FORTRAN_COMPILER) = "yes" ]; then\
+		cd F-FrontEnd/src && bash ./compile_all_test.sh;\
+	else\
+	    echo "Fortran tests disabled because of --without-native-fortran-compiler";\
+    fi
 	cd test/C99; make clean; make CC=$(CC)
 
 install:

--- a/configure
+++ b/configure
@@ -707,6 +707,7 @@ LEX
 YFLAGS
 YACC
 AWK
+WITH_NATIVE_FORTRAN_COMPILER
 ac_ct_FC
 FCFLAGS
 FC
@@ -4628,6 +4629,8 @@ else
     { $as_echo "$as_me:${as_lineno-$LINENO}: \"fortran native compiler check disabled\"" >&5
 $as_echo "$as_me: \"fortran native compiler check disabled\"" >&6;}
 fi
+WITH_NATIVE_FORTRAN_COMPILER=$with_native_fortran_compiler
+
 
 #AC_PROG_MAKE_SET
 for ac_prog in gawk mawk nawk awk

--- a/configure
+++ b/configure
@@ -772,6 +772,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_native_fortran_compiler
 with_libxml2
 with_libxml2_include
 with_libxml2_lib
@@ -1438,6 +1439,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --without-native-fortran-compiler  Disable Fortran native compiler check
   --with-libxml2=DIR          specify prefix directory for installed libxml2 package (default: /usr)
                               Equivalent to --with-libxml2-include=PATH/include plus --with-libxml2-lib=PATH/lib64
   --with-libxml2-include=DIR  specify directory for installed libxml2 include files
@@ -2929,6 +2931,17 @@ realpath ()
 }
 
 #--------------------------------------------------------------------
+
+
+# Check whether --with-native-fortran-compiler was given.
+if test "${with_native_fortran_compiler+set}" = set; then :
+  withval=$with_native_fortran_compiler;
+else
+  with_native_fortran_compiler=yes
+fi
+
+
+#--------------------------------------------------------------------
 # Save environmental variables set by user before AC_PROG_CC and so on.
 userCFLAGS=${CFLAGS}
 
@@ -4398,7 +4411,9 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-ac_ext=${ac_fc_srcext-f}
+
+if test "x$with_native_fortran_compiler" = "xyes"; then
+    ac_ext=${ac_fc_srcext-f}
 ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
 ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_fc_compiler_gnu
@@ -4608,6 +4623,11 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: \"fortran native compiler check disabled\"" >&5
+$as_echo "$as_me: \"fortran native compiler check disabled\"" >&6;}
+fi
 
 #AC_PROG_MAKE_SET
 for ac_prog in gawk mawk nawk awk
@@ -7868,6 +7888,7 @@ else
 fi
 
 
+if test "x$with_native_fortran_compiler" = "xyes"; then
 # Check whether --enable-mod2xmod was given.
 if test "${enable_mod2xmod+set}" = set; then :
   enableval=$enable_mod2xmod; domod2xmod=yes
@@ -7875,6 +7896,7 @@ else
   domod2xmod=no
 fi
 
+fi
 
 # Check whether --enable-gnu-extension was given.
 if test "${enable_gnu_extension+set}" = set; then :
@@ -7956,6 +7978,8 @@ fi
 
 
 #--------------------------------------------------------------------
+if test "x$with_native_fortran_compiler" = "xyes"; then
+
 # check --enable-mod2xmod
 if test "x${target}" = "xKcomputer-linux-gnu" -o "x${target}" = "xFX10-linux-gnu" -o "x${target}" = "xFX100-linux-gnu"; then
   KIND_FORTRAN=frtpx
@@ -8056,6 +8080,17 @@ if test "$NEED_MAKE_MOD2XMOD" = $TRUE; then
 
 fi
 
+else # with_native_fortran_compiler != yes
+
+NEED_MAKE_MOD2XMOD=$FALSE
+KIND_FORTRAN=none
+MOD2XMOD=$FALSE
+
+
+
+
+
+fi # with_native_fortran_compiler = yes
 #--------------------------------------------------------------------
 # check Perl versoin is 5
 # Extract the first word of "perl", so it can be a program name with args.

--- a/configure.in
+++ b/configure.in
@@ -23,13 +23,25 @@ realpath ()
 }
 
 #--------------------------------------------------------------------
+
+AC_ARG_WITH(native-fortran-compiler,
+	    [  --without-native-fortran-compiler  Disable Fortran native compiler check ],
+		[], [with_native_fortran_compiler=yes])
+
+#--------------------------------------------------------------------
 # Save environmental variables set by user before AC_PROG_CC and so on.
 userCFLAGS=${CFLAGS}
 
 # Checks for programs.
 AC_PROG_CPP
 AC_PROG_CC
-AC_PROG_FC
+
+if test "x$with_native_fortran_compiler" = "xyes"; then
+    AC_PROG_FC
+else
+    AC_MSG_NOTICE(["fortran native compiler check disabled"])
+fi
+
 #AC_PROG_MAKE_SET
 AC_PROG_AWK
 AC_PROG_YACC
@@ -216,9 +228,11 @@ AC_ARG_ENABLE(atool,
   [  --enable-atool          enable atool (false default)],
   [doatool=yes], [doatool=no])
 
+if test "x$with_native_fortran_compiler" = "xyes"; then
 AC_ARG_ENABLE(mod2xmod,
   [  --enable-mod2xmod       enable to translate .mod to .xmod on only gfortran (false default)],
   [domod2xmod=yes], [domod2xmod=no])
+fi
 
 AC_ARG_ENABLE(gnu-extension,
   [  --enable-gnu-extension  enable Fortran GNU intrinsic extension (false default).],
@@ -296,6 +310,8 @@ AC_SUBST(UCHARDET_INCLUDE_DIR)
 AC_SUBST(UCHARDET_LIB_DIR)
 
 #--------------------------------------------------------------------
+if test "x$with_native_fortran_compiler" = "xyes"; then
+
 # check --enable-mod2xmod
 if test "x${target}" = "xKcomputer-linux-gnu" -o "x${target}" = "xFX10-linux-gnu" -o "x${target}" = "xFX100-linux-gnu"; then
   KIND_FORTRAN=frtpx
@@ -396,6 +412,17 @@ if test "$NEED_MAKE_MOD2XMOD" = $TRUE; then
     AC_SUBST(MPFR_LIB_DIR)
 fi
 
+else # with_native_fortran_compiler != yes
+
+NEED_MAKE_MOD2XMOD=$FALSE
+KIND_FORTRAN=none
+MOD2XMOD=$FALSE
+
+AC_SUBST(MOD2XMOD)
+AC_SUBST(KIND_FORTRAN)
+AC_SUBST(NEED_MAKE_MOD2XMOD)
+
+fi # with_native_fortran_compiler = yes
 #--------------------------------------------------------------------
 # check Perl versoin is 5
 AC_CHECK_PROG(PERL5, [perl], [perl])

--- a/configure.in
+++ b/configure.in
@@ -41,6 +41,7 @@ if test "x$with_native_fortran_compiler" = "xyes"; then
 else
     AC_MSG_NOTICE(["fortran native compiler check disabled"])
 fi
+AC_SUBST(WITH_NATIVE_FORTRAN_COMPILER, $with_native_fortran_compiler)
 
 #AC_PROG_MAKE_SET
 AC_PROG_AWK


### PR DESCRIPTION
Added build configure cmdline option "--without-native-fortran-compiler" which optionally removes dependency on Fortran native compiler being available.