### PR TITLE
Added version printing cmdline options

### DIFF
--- a/F-FrontEnd/src/F95-main.c
+++ b/F-FrontEnd/src/F95-main.c
@@ -151,7 +151,8 @@ static void usage()
         "-endlineno                output the endlineno attribute.", "",
         "internal options:", "-d                        enable debug mode.",
         "-no-module-cache          always load module from file.",
-        "--version                 display frontend version information.",
+        "--version                 display frontend version information."
+        "--version-tag             display frontend version tag (if any).",
 
         NULL};
     const char *const *p = usages;
@@ -164,7 +165,7 @@ static void usage()
 }
 
 void print_version() {
-    fprintf(stderr, "%s", PACKAGE_STRING, PACKAGE_VERSION);
+    fprintf(stderr, "%s", PACKAGE_STRING);
     if(strlen(PACKAGE_VERSION_TAG) > 0)
     { fprintf(stderr, " \"%s\"", PACKAGE_VERSION_TAG); }
     fprintf(stderr, "\n");

--- a/F-FrontEnd/src/F95-main.c
+++ b/F-FrontEnd/src/F95-main.c
@@ -124,7 +124,7 @@ static void usage()
         "-fxmp                     enable XcalableMP translation.",
 	"-pgi                      keep PGI directives",
         "-fno-xmp-coarray          disable translation coarray statements to "
-        "XcalableMP subroutin calls.",
+        "XcalableMP subroutine calls.",
         "-fintrinsic-xmodules-path specify a xmod path for the intrinsic "
         "modules.",
         "-Kscope-omp               enable conditional compilation.",
@@ -151,6 +151,7 @@ static void usage()
         "-endlineno                output the endlineno attribute.", "",
         "internal options:", "-d                        enable debug mode.",
         "-no-module-cache          always load module from file.",
+        "--version                 display frontend version information.",
 
         NULL};
     const char *const *p = usages;
@@ -160,6 +161,17 @@ static void usage()
     while (*p != NULL) {
         fprintf(stderr, "%s\n", *(p++));
     }
+}
+
+void print_version() {
+    fprintf(stderr, "%s", PACKAGE_STRING, PACKAGE_VERSION);
+    if(strlen(PACKAGE_VERSION_TAG) > 0)
+    { fprintf(stderr, " \"%s\"", PACKAGE_VERSION_TAG); }
+    fprintf(stderr, "\n");
+}
+
+void print_version_tag() {
+    fprintf(stderr, "%s", PACKAGE_VERSION_TAG);
 }
 
 int main(argc, argv) int argc;
@@ -399,6 +411,12 @@ char *argv[];
             exit(0);
         } else if (strcmp(argv[0], "-no-module-cache") == 0) {
             flag_do_module_cache = FALSE;
+        } else if (strcmp(argv[0], "--version") == 0) {
+            print_version();
+            exit(0);
+        } else if (strcmp(argv[0], "--version-tag") == 0) {
+            print_version_tag();
+            exit(0);
         } else {
             cmd_error_exit("unknown option : %s", argv[0]);
         }

--- a/XcodeML-Common/src/xcodeml/util/AppConstants.java.in
+++ b/XcodeML-Common/src/xcodeml/util/AppConstants.java.in
@@ -1,0 +1,11 @@
+package xcodeml.util;
+
+public class AppConstants
+{
+    private AppConstants() {}
+    public static final String PACKAGE_NAME = "@PACKAGE_NAME@";
+    public static final String PACKAGE_STRING = "@PACKAGE_STRING@";
+    public static final String PACKAGE_TARNAME = "@PACKAGE_TARNAME@";
+    public static final String PACKAGE_VERSION = "@PACKAGE_VERSION@";
+    public static final String PACKAGE_VERSION_TAG = "@VERSION_TAG@";
+};

--- a/XcodeML-Common/src/xcodeml/util/XmBackEnd.java
+++ b/XcodeML-Common/src/xcodeml/util/XmBackEnd.java
@@ -63,11 +63,26 @@ public class XmBackEnd
             "  -w N          set max columns to N for Fortran source code.",
             "  -d            enable debug output.",
             "  -h,--help     print this message.",
+            "  --version     display frontend version information.",
+            "  --version-tag display frontend version tag (if any)."
         };
         
         for(String line : lines) {
             System.err.println(line);
         }
+    }
+
+    private void _print_version()
+    {
+        System.err.printf("%s", AppConstants.PACKAGE_STRING);
+        if(!AppConstants.PACKAGE_VERSION_TAG.isEmpty())
+        { System.err.printf(" \"%s\"", AppConstants.PACKAGE_VERSION_TAG); }
+        System.err.printf("\n");
+    }
+
+    private void _print_version_tag()
+    {
+        System.err.printf("%s", AppConstants.PACKAGE_VERSION_TAG);
     }
 
     private boolean _openInputFile()
@@ -135,7 +150,13 @@ public class XmBackEnd
                     coarray_useStmt = true;
                 } else if(arg.equals("--help") || arg.equals("-h")) {
                     _usage();
-                    System.exit(1);
+                    System.exit(0);
+                } else if(arg.equals("--version")) {
+                    _print_version();
+                    System.exit(0);
+                } else if(arg.equals("--version-tag")) {
+                    _print_version_tag();
+                    System.exit(0);
                 } else {
                     _error("Unknown option " + arg + ".");
                 }

--- a/configure
+++ b/configure
@@ -718,6 +718,7 @@ CPPFLAGS
 LDFLAGS
 CFLAGS
 CC
+VERSION_TAG
 target_os
 target_vendor
 target_cpu
@@ -772,6 +773,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_version_tag
 with_libxml2
 with_libxml2_include
 with_libxml2_lib
@@ -1438,6 +1440,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-version-tag=<tag> Add arbitrary string tag to the xcodeml-tools version
   --with-libxml2=DIR          specify prefix directory for installed libxml2 package (default: /usr)
                               Equivalent to --with-libxml2-include=PATH/include plus --with-libxml2-lib=PATH/lib64
   --with-libxml2-include=DIR  specify directory for installed libxml2 include files
@@ -2910,6 +2913,43 @@ test -n "$target_alias" &&
   program_prefix=${target_alias}-
 
 ac_config_headers="$ac_config_headers include/config.h Driver/atool/src/include/nata/nata_config.h"
+
+
+#--------------------------------------------------------------------
+# Bash function for trimming strings
+trim ()
+{
+    local var="$*"
+    # remove leading whitespace characters
+    var="${var#"${var%%[![:space:]]*}"}"
+    # remove trailing whitespace characters
+    var="${var%"${var##*[![:space:]]}"}"
+    printf '%s' "$var"
+}
+#--------------------------------------------------------------------
+
+
+# Check whether --with-version-tag was given.
+if test "${with_version_tag+set}" = set; then :
+  withval=$with_version_tag; with_version_tag_specified=yes
+else
+  with_version_tag_specified=no
+fi
+
+
+if test "x${with_version_tag_specified}" = "xyes"; then
+  # Trim tag string
+  with_version_tag=$(trim "${with_version_tag}")
+else
+  with_version_tag=
+fi
+
+
+cat >>confdefs.h <<_ACEOF
+#define PACKAGE_VERSION_TAG "$with_version_tag"
+_ACEOF
+
+VERSION_TAG=$with_version_tag
 
 
 #--------------------------------------------------------------------

--- a/configure
+++ b/configure
@@ -10044,6 +10044,8 @@ ac_config_files="$ac_config_files Driver/bin/F_Back"
 
 ac_config_files="$ac_config_files Makefile"
 
+ac_config_files="$ac_config_files XcodeML-Common/src/xcodeml/util/AppConstants.java"
+
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -10770,6 +10772,7 @@ do
     "Driver/bin/C_Back") CONFIG_FILES="$CONFIG_FILES Driver/bin/C_Back" ;;
     "Driver/bin/F_Back") CONFIG_FILES="$CONFIG_FILES Driver/bin/F_Back" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "XcodeML-Common/src/xcodeml/util/AppConstants.java") CONFIG_FILES="$CONFIG_FILES XcodeML-Common/src/xcodeml/util/AppConstants.java" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.in
+++ b/configure.in
@@ -7,6 +7,34 @@ AC_CONFIG_SRCDIR([include/exc_platform.h])
 AC_CONFIG_HEADER([include/config.h Driver/atool/src/include/nata/nata_config.h])
 
 #--------------------------------------------------------------------
+# Bash function for trimming strings
+trim ()
+{
+    local var="$*"
+    # remove leading whitespace characters
+    var="${var#"${var%%[![:space:]]*}"}"
+    # remove trailing whitespace characters
+    var="${var%"${var##*[![:space:]]}"}"
+    printf '%s' "$var"
+}
+#--------------------------------------------------------------------
+
+AC_ARG_WITH(version-tag,
+	    [  --with-version-tag=<tag> Add arbitrary string tag to the xcodeml-tools version],
+		[with_version_tag_specified=yes], [with_version_tag_specified=no])
+
+if test "x${with_version_tag_specified}" = "xyes"; then
+  # Trim tag string
+  with_version_tag=$(trim "${with_version_tag}")
+else
+  with_version_tag=
+fi
+
+AC_DEFINE_UNQUOTED([PACKAGE_VERSION_TAG], ["$with_version_tag"], [String tag addition to package version])
+VERSION_TAG=$with_version_tag
+AC_SUBST(VERSION_TAG)
+
+#--------------------------------------------------------------------
 # See http://unix.stackexchange.com/questions/101080/realpath-command-not-found
 realpath ()
 {

--- a/configure.in
+++ b/configure.in
@@ -4,7 +4,7 @@ AC_CONFIG_AUX_DIR([./buildutils])
 AC_CONFIG_MACRO_DIR([./buildutils])
 AC_CANONICAL_TARGET
 AC_CONFIG_SRCDIR([include/exc_platform.h])
-AC_CONFIG_HEADER([include/config.h Driver/atool/src/include/nata/nata_config.h])
+AC_CONFIG_HEADER([include/config.h Driver/atool/src/include/nata/nata_config.h ])
 
 #--------------------------------------------------------------------
 # Bash function for trimming strings
@@ -1076,5 +1076,6 @@ AC_CONFIG_FILES(Driver/bin/Makefile)
 AC_CONFIG_FILES(Driver/bin/C_Back)
 AC_CONFIG_FILES(Driver/bin/F_Back)
 AC_CONFIG_FILES(Makefile)
+AC_CONFIG_FILES(XcodeML-Common/src/xcodeml/util/AppConstants.java)
 
 AC_OUTPUT

--- a/configure.in
+++ b/configure.in
@@ -4,7 +4,7 @@ AC_CONFIG_AUX_DIR([./buildutils])
 AC_CONFIG_MACRO_DIR([./buildutils])
 AC_CANONICAL_TARGET
 AC_CONFIG_SRCDIR([include/exc_platform.h])
-AC_CONFIG_HEADER([include/config.h Driver/atool/src/include/nata/nata_config.h ])
+AC_CONFIG_HEADER([include/config.h Driver/atool/src/include/nata/nata_config.h])
 
 #--------------------------------------------------------------------
 # Bash function for trimming strings

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -301,6 +301,9 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
+/* String tag addition to package version. */
+#undef PACKAGE_VERSION_TAG
+
 /* The size of `double', as computed by sizeof. */
 #undef SIZEOF_DOUBLE
 


### PR DESCRIPTION
Added version tag, extending the original version number of the package. Additionally added cmdline options --version and --version-tag to F_Front and F_Back.

Background: company which produced XCodeMLTools no longer supports them, it is unlikely that there will ever be another version increase. Because of that introduced an optional tag (arbitrary string) which will be added to the version. In practise, that would be git commit's hash.