### PR TITLE
Switched F_Back to take OMNI_JAVA variable from shell by default

### DIFF
--- a/Driver/bin/F_Back.in
+++ b/Driver/bin/F_Back.in
@@ -28,6 +28,8 @@ else
     OMNI_JAR2="../XcodeML-Common/build/om-common.jar"
 fi
 
+if [ -z ${OMNI_JAVA+x} ]; then
 OMNI_JAVA=@JAVA@
+fi
 OMNI_JAVA_OPT="-Xmx200m -Xms200m -cp ${OMNI_JAR2}:${OMNI_JAR1} xcodeml.f.util.omx2f"
 exec ${OMNI_JAVA} ${OMNI_JAVA_OPT} ${_other_args[@]}


### PR DESCRIPTION
This is needed so that spack can provide Java path at runtime